### PR TITLE
Add support for CNN(Resnet) backbone

### DIFF
--- a/backbone/resnet.py
+++ b/backbone/resnet.py
@@ -267,7 +267,7 @@ def _resnet(arch, block, layers, pretrained, progress, **kwargs):
     if pretrained:
         state_dict = load_state_dict_from_url(model_urls[arch],
                                               progress=progress)
-        model.load_state_dict(state_dict)
+        model.load_state_dict(state_dict, strict=False)
     return model
 
 

--- a/utils/inc_net.py
+++ b/utils/inc_net.py
@@ -4,6 +4,7 @@ import torch
 from torch import nn
 from backbone.linears import SimpleLinear, SplitCosineLinear, CosineLinear
 from backbone.prompt import CodaPrompt
+from backbone.resnet import resnet18, resnet34, resnet50, resnet101, resnet152
 import timm
 
 def get_backbone(args, pretrained=False):
@@ -17,6 +18,19 @@ def get_backbone(args, pretrained=False):
         model = timm.create_model("vit_base_patch16_224_in21k",pretrained=True, num_classes=0)
         model.out_dim = 768
         return model.eval()
+    # resnet backbone
+    elif 'resnet' in name:
+        if name == "resnet18":
+            model = resnet18(pretrained=True, args=args)
+        elif name == "resnet34":
+            model = resnet34(pretrained=True, args=args)
+        elif name == "resnet50":
+            model = resnet50(pretrained=True, args=args)
+        elif name == "resnet101":
+            model = resnet101(pretrained=True, args=args)
+        elif name == "resnet152":
+            model = resnet152(pretrained=True, args=args)
+        return model
 
     elif '_memo' in name:
         if args["model_name"] == "memo":

--- a/utils/inc_net.py
+++ b/utils/inc_net.py
@@ -207,7 +207,7 @@ class BaseNet(nn.Module):
 
     def extract_vector(self, x):
         if self.model_type == 'cnn':
-            self.backbone(x)['features']
+            return self.backbone(x)['features']
         else:
             return self.backbone(x)
 


### PR DESCRIPTION
Hi! Your repository is really fantastic and has implemented a lot of continual models based on pre-trained transformers. 

I notice that in your `backbone` folder resnet is implemented but never used. So, I referred to your previous [repository](https://github.com/g-u-n/pycil) and added support for resnet in `inc_net.py`. 

Here are my changes:
* **Add support for resnet.** When `args["backbone_type"]` is set as resnetxx, the function `get_backbone()` will return the corresponding resnet block implemented in `backbone/resnet.py`.
* **Fix a small bug** in `inc_net.py`, the `extract_vector()` function failed to return features from a CNN in the past, and now I have fixed this small bug.

This change does work well on my machine and I would like to share it with other users.

Yours sincerely